### PR TITLE
Centralize navigation data

### DIFF
--- a/fahndung-001/src/components/layout/header/DesktopHeader.tsx
+++ b/fahndung-001/src/components/layout/header/DesktopHeader.tsx
@@ -6,6 +6,7 @@ import ThemeToggle from '../ui/ThemeToggle';
 import A11nav from '../ui/a11nav';
 import UserAuth from '../ui/UserAuth';
 import { HoverMegaMenu } from './HoverMegaMenu';
+import { navigation } from "~/lib/navigation";
 import { SearchModal } from './SearchModal';
 import A11accessDropdown from '../ui/A11accessDropdown';
 
@@ -36,9 +37,9 @@ export default function DesktopHeader({ isScrolled, breadcrumb }: DesktopHeaderP
           aria-label="Hauptnavigation Desktop"
         >
           {/* Mega Menu Items */}
-          <HoverMegaMenu title="SICHERHEIT" />
-          <HoverMegaMenu title="SERVICE" />
-          <HoverMegaMenu title="POLIZEI" />
+          {navigation.map((section) => (
+            <HoverMegaMenu key={section.id} section={section} />
+          ))}
           {/* Right Actions */}
           <div className="flex items-center gap-3 ml-6">
             <ThemeToggle />

--- a/fahndung-001/src/components/layout/header/HoverMegaMenu.tsx
+++ b/fahndung-001/src/components/layout/header/HoverMegaMenu.tsx
@@ -10,16 +10,10 @@ import {
   NavigationMenuTrigger,
 } from "~/components/ui/navigation-menu";
 import { cn } from "~/lib/utils";
+import type { NavigationSection } from "~/lib/navigation";
 
 interface HoverMegaMenuProps {
-  title: string;
-}
-
-interface MenuItem {
-  label: string;
-  href: string;
-  description: string;
-  urgent?: boolean;
+  section: NavigationSection;
 }
 
 /**
@@ -28,79 +22,8 @@ interface MenuItem {
  * Keyboard Navigation und Focus Management
  * Jetzt mit Schadcn/UI NavigationMenu
  */
-export function HoverMegaMenu({ title }: HoverMegaMenuProps) {
-  // Menu Data
-  const menuData: Record<string, MenuItem[]> = {
-    'SICHERHEIT': [
-      { 
-        label: 'Aktuelle Fahndungen', 
-        href: '/fahndungen/aktuell', 
-        description: 'Öffentliche Fahndungen und Eilmeldungen', 
-        urgent: true 
-      },
-      { 
-        label: 'Vermisste Personen', 
-        href: '/vermisste', 
-        description: 'Vermisstenfälle in Baden-Württemberg'
-      },
-      { 
-        label: 'Gesuchte Straftäter', 
-        href: '/gesuchte', 
-        description: 'Öffentliche Straftätersuche'
-      },
-      { 
-        label: 'Sicherheitswarnungen', 
-        href: '/warnungen', 
-        description: 'Aktuelle Warnungen und Betrugsmeldungen'
-      }
-    ],
-    'SERVICE': [
-      { 
-        label: 'Hinweise melden', 
-        href: '/hinweise/melden', 
-        description: 'Sichere Hinweisübermittlung'
-      },
-      { 
-        label: 'Online-Anzeige', 
-        href: '/anzeige/online', 
-        description: 'Strafanzeige online erstatten'
-      },
-      { 
-        label: 'Notruf & Kontakt', 
-        href: '/kontakt', 
-        description: 'Notrufnummern und Dienststellen'
-      },
-      { 
-        label: 'Bürgerservice', 
-        href: '/service', 
-        description: 'Führungszeugnis und Services'
-      }
-    ],
-    'POLIZEI': [
-      { 
-        label: 'Über die Polizei BW', 
-        href: '/ueber-uns', 
-        description: 'Organisation und Aufgaben'
-      },
-      { 
-        label: 'Dienststellen', 
-        href: '/dienststellen', 
-        description: 'Standorte und Öffnungszeiten'
-      },
-      { 
-        label: 'Karriere', 
-        href: '/karriere', 
-        description: 'Ausbildung und Stellenangebote'
-      },
-      { 
-        label: 'Presse', 
-        href: '/presse', 
-        description: 'Pressemitteilungen und Medien'
-      }
-    ]
-  };
-
-  const items = menuData[title] ?? [];
+export function HoverMegaMenu({ section }: HoverMegaMenuProps) {
+  const { title, items } = section;
 
   return (
     <NavigationMenu>

--- a/fahndung-001/src/components/layout/header/MobileMenu.tsx
+++ b/fahndung-001/src/components/layout/header/MobileMenu.tsx
@@ -14,8 +14,8 @@ import {
   AccordionTrigger,
 } from "~/components/ui/accordion";
 import ThemeToggle from '../ui/ThemeToggle';
-import { navigationData } from '../../constants/navigationData';
-import type { MenuSection } from '../../types/header';
+import { navigation } from "~/lib/navigation";
+import type { NavigationSection } from "~/lib/navigation";
 import A11accessDropdown from '../ui/A11accessDropdown';
 import { cn } from "~/lib/utils";
 
@@ -34,20 +34,7 @@ export function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
   const firstFocusableRef = useRef<HTMLButtonElement>(null);
 
   // Menu Data
-  const menuSections: MenuSection[] = [
-    {
-      title: 'SICHERHEIT',
-      items: navigationData.SICHERHEIT
-    },
-    {
-      title: 'SERVICE',
-      items: navigationData.SERVICE
-    },
-    {
-      title: 'POLIZEI',
-      items: navigationData.POLIZEI
-    }
-  ];
+  const menuSections: NavigationSection[] = navigation;
 
   // Focus Management
   useEffect(() => {

--- a/fahndung-001/src/components/types/header.ts
+++ b/fahndung-001/src/components/types/header.ts
@@ -1,6 +1,6 @@
-import type { MenuItem, MenuSection } from '../constants/navigationData';
+import type { NavigationItem, NavigationSection } from "~/lib/navigation";
 
-export type { MenuItem, MenuSection };
+export type { NavigationItem as MenuItem, NavigationSection as MenuSection };
 
 export interface HeaderProps {
   className?: string;
@@ -30,6 +30,5 @@ export interface SearchBarProps {
 }
 
 export interface HoverMegaMenuProps {
-  title: string;
-  items?: MenuItem[];
-} 
+  section: MenuSection;
+}

--- a/fahndung-001/src/lib/navigation.ts
+++ b/fahndung-001/src/lib/navigation.ts
@@ -1,0 +1,94 @@
+export interface NavigationItem {
+  label: string;
+  href: string;
+  description: string;
+  urgent?: boolean;
+}
+
+export interface NavigationSection {
+  title: string;
+  id: string;
+  items: NavigationItem[];
+}
+
+export const navigation: NavigationSection[] = [
+  {
+    title: 'SICHERHEIT',
+    id: 'sicherheit',
+    items: [
+      {
+        label: 'Aktuelle Fahndungen',
+        href: '/fahndungen/aktuell',
+        description: 'Öffentliche Fahndungen und Eilmeldungen',
+        urgent: true,
+      },
+      {
+        label: 'Vermisste Personen',
+        href: '/vermisste',
+        description: 'Vermisstenfälle in Baden-Württemberg',
+      },
+      {
+        label: 'Gesuchte Straftäter',
+        href: '/gesuchte',
+        description: 'Öffentliche Straftätersuche',
+      },
+      {
+        label: 'Sicherheitswarnungen',
+        href: '/warnungen',
+        description: 'Aktuelle Warnungen und Betrugsmeldungen',
+      },
+    ],
+  },
+  {
+    title: 'SERVICE',
+    id: 'service',
+    items: [
+      {
+        label: 'Hinweise melden',
+        href: '/hinweise/melden',
+        description: 'Sichere Hinweisübermittlung',
+      },
+      {
+        label: 'Online-Anzeige',
+        href: '/anzeige/online',
+        description: 'Strafanzeige online erstatten',
+      },
+      {
+        label: 'Notruf & Kontakt',
+        href: '/kontakt',
+        description: 'Notrufnummern und Dienststellen',
+      },
+      {
+        label: 'Bürgerservice',
+        href: '/service',
+        description: 'Führungszeugnis und Services',
+      },
+    ],
+  },
+  {
+    title: 'POLIZEI',
+    id: 'polizei',
+    items: [
+      {
+        label: 'Über die Polizei BW',
+        href: '/ueber-uns',
+        description: 'Organisation und Aufgaben',
+      },
+      {
+        label: 'Dienststellen',
+        href: '/dienststellen',
+        description: 'Standorte und Öffnungszeiten',
+      },
+      {
+        label: 'Karriere',
+        href: '/karriere',
+        description: 'Ausbildung und Stellenangebote',
+      },
+      {
+        label: 'Presse',
+        href: '/presse',
+        description: 'Pressemitteilungen und Medien',
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- add shared navigation definitions
- refactor header components to pull from the new module
- update type definitions

## Testing
- `pnpm run test` *(fails: Missing script)*
- `pnpm format:write` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_686f6d1d018c8328a2d7fce9e8089b92