### PR TITLE
Add RBAC utilities

### DIFF
--- a/fahndung-001/src/lib/permissions.ts
+++ b/fahndung-001/src/lib/permissions.ts
@@ -1,0 +1,7 @@
+export const ROLE_PERMISSIONS: Record<string, string[]> = {
+  ADMIN: ["*"],
+  USER: [],
+};
+
+export type Role = keyof typeof ROLE_PERMISSIONS;
+export type Permission = string;

--- a/fahndung-001/src/server/auth/rbac.ts
+++ b/fahndung-001/src/server/auth/rbac.ts
@@ -1,0 +1,40 @@
+import { redirect } from "next/navigation";
+
+import { ROLE_PERMISSIONS } from "~/lib/permissions";
+import { auth } from "./index";
+
+export async function requireAuth() {
+  const session = await auth();
+  if (!session?.user) {
+    redirect("/unauthorized");
+  }
+  return session;
+}
+
+export async function requireRole(allowedRoles: string[] | string) {
+  const session = await requireAuth();
+  const role = (session.user as Record<string, unknown>).role as string | undefined;
+  const roles = Array.isArray(allowedRoles) ? allowedRoles : [allowedRoles];
+
+  if (!role || !roles.includes(role)) {
+    redirect("/unauthorized");
+  }
+
+  return session;
+}
+
+export async function checkPermission(permission: string) {
+  const session = await auth();
+  const role = (session?.user as Record<string, unknown> | undefined)?.role as string | undefined;
+  if (!role) return false;
+
+  const permissions = ROLE_PERMISSIONS[role] ?? [];
+  return permissions.includes("*") || permissions.includes(permission);
+}
+
+export async function requirePermission(permission: string) {
+  const allowed = await checkPermission(permission);
+  if (!allowed) {
+    redirect("/unauthorized");
+  }
+}


### PR DESCRIPTION
## Summary
- add role permissions mapping
- implement RBAC helpers to require auth, roles and permissions

## Testing
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f77f49180832894f70fb90169524e