### PR TITLE
Add admin layout with restricted access

### DIFF
--- a/fahndung-001/src/app/admin/layout.tsx
+++ b/fahndung-001/src/app/admin/layout.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from "react";
+import AdminNav from "~/components/admin/AdminNav";
+import UserMenu from "~/components/admin/UserMenu";
+import { requireRole } from "~/server/auth/requireRole";
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  await requireRole(["ADMIN", "EDITOR"]);
+
+  return (
+    <div className="flex min-h-screen">
+      <aside className="w-64 border-r bg-gray-50 dark:bg-gray-950 p-4">
+        <AdminNav />
+      </aside>
+      <div className="flex flex-1 flex-col">
+        <header className="flex items-center justify-end border-b p-4">
+          <UserMenu />
+        </header>
+        <main className="flex-1 p-4">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/fahndung-001/src/components/admin/AdminNav.tsx
+++ b/fahndung-001/src/components/admin/AdminNav.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { LayoutDashboard, Users, FileText } from "lucide-react";
+import { cn } from "~/lib/utils";
+
+const links = [
+  { href: "/admin", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/admin/users", label: "Users", icon: Users },
+  { href: "/admin/posts", label: "Posts", icon: FileText },
+];
+
+export default function AdminNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="space-y-1">
+      {links.map(({ href, label, icon: Icon }) => (
+        <Link
+          key={href}
+          href={href}
+          className={cn(
+            "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-200 dark:hover:bg-gray-800",
+            pathname.startsWith(href)
+              ? "bg-gray-200 dark:bg-gray-800 text-blue-600 dark:text-blue-400"
+              : "text-gray-700 dark:text-gray-300"
+          )}
+        >
+          <Icon className="h-4 w-4" />
+          {label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/fahndung-001/src/components/admin/UserMenu.tsx
+++ b/fahndung-001/src/components/admin/UserMenu.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { User, LogOut } from "lucide-react";
+
+export default function UserMenu() {
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const update = () => {
+      setLoggedIn(Boolean(localStorage.getItem("demo-session")));
+    };
+    update();
+    window.addEventListener("storage", update);
+    window.addEventListener("demo-session-changed", update);
+    return () => {
+      window.removeEventListener("storage", update);
+      window.removeEventListener("demo-session-changed", update);
+    };
+  }, []);
+
+  function handleLogout() {
+    localStorage.removeItem("demo-session");
+    window.dispatchEvent(new Event("demo-session-changed"));
+    location.href = "/";
+  }
+
+  if (!loggedIn) {
+    return (
+      <Link href="/login" className="flex items-center gap-2 text-sm">
+        <User className="h-4 w-4" /> Login
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleLogout}
+      className="flex items-center gap-2 text-sm text-red-600 hover:underline"
+    >
+      <LogOut className="h-4 w-4" /> Logout
+    </button>
+  );
+}

--- a/fahndung-001/src/server/auth/requireRole.ts
+++ b/fahndung-001/src/server/auth/requireRole.ts
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation";
+import { auth } from "./index";
+
+export async function requireRole(roles: string[]) {
+  const session = await auth();
+  const role = (session?.user as { role?: string } | undefined)?.role;
+  if (!session || !role || !roles.includes(role)) {
+    redirect("/login");
+  }
+}


### PR DESCRIPTION
## Summary
- add server-only `requireRole` helper
- implement sidebar navigation and user menu for admin area
- create `/admin` layout that requires `ADMIN` or `EDITOR` role

## Testing
- `pnpm install`
- `SKIP_ENV_VALIDATION=1 pnpm lint` *(fails: eslint errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_686f77f5628083288728a5347a642663