### PR TITLE
Implement Audit Log with SSE

### DIFF
--- a/fahndung-001/prisma/schema.prisma
+++ b/fahndung-001/prisma/schema.prisma
@@ -73,3 +73,19 @@ model VerificationToken {
 
   @@unique([identifier, token])
 }
+
+model AuditLog {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  userId    String?
+  ip        String?
+  userAgent String?
+
+  action   String
+  entity   String
+  entityId String
+  success  Boolean
+  details  Json
+
+  @@index([entity, entityId])
+}

--- a/fahndung-001/src/app/api/audit/stream/route.ts
+++ b/fahndung-001/src/app/api/audit/stream/route.ts
@@ -1,0 +1,33 @@
+import { auditEvents } from "~/lib/audit";
+import { NextRequest } from "next/server";
+
+export function GET(_req: NextRequest) {
+  const encoder = new TextEncoder();
+  let keepAlive: NodeJS.Timeout;
+  let listener: (event: Event) => void;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      listener = (event: Event) => {
+        const payload = JSON.stringify((event as CustomEvent).detail);
+        controller.enqueue(encoder.encode(`data: ${payload}\n\n`));
+      };
+      auditEvents.addEventListener("log", listener);
+      keepAlive = setInterval(() => {
+        controller.enqueue(encoder.encode(`:\n\n`));
+      }, 15000);
+    },
+    cancel() {
+      auditEvents.removeEventListener("log", listener);
+      clearInterval(keepAlive);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/fahndung-001/src/lib/audit.ts
+++ b/fahndung-001/src/lib/audit.ts
@@ -1,0 +1,38 @@
+import { db } from "~/server/db";
+
+export interface AuditLogInput {
+  action: string;
+  entity: string;
+  entityId: string;
+  success: boolean;
+  details?: unknown;
+  userId?: string | null;
+  headers?: Headers;
+}
+
+export const auditEvents = new EventTarget();
+
+export async function createAuditLog(input: AuditLogInput) {
+  const ip =
+    input.headers?.get("x-forwarded-for") ??
+    input.headers?.get("x-real-ip") ??
+    input.headers?.get("cf-connecting-ip") ??
+    null;
+  const userAgent = input.headers?.get("user-agent") ?? null;
+
+  const log = await db.auditLog.create({
+    data: {
+      action: input.action,
+      entity: input.entity,
+      entityId: input.entityId,
+      success: input.success,
+      details: input.details as any,
+      userId: input.userId,
+      ip,
+      userAgent,
+    },
+  });
+
+  auditEvents.dispatchEvent(new CustomEvent("log", { detail: log }));
+  return log;
+}


### PR DESCRIPTION
## Summary
- add `AuditLog` model to Prisma schema
- log CRUD activity to DB and dispatch events via `createAuditLog`
- expose `/api/audit/stream` for server-sent events
- audit Post creation via tRPC

## Testing
- `pnpm --filter ./fahndung-001 exec prisma generate`
- `SKIP_ENV_VALIDATION=1 pnpm --filter ./fahndung-001 run lint` *(fails: Unsafe assignments, etc.)*
- `SKIP_ENV_VALIDATION=1 pnpm --filter ./fahndung-001 run typecheck` *(fails: TS1005)*

------
https://chatgpt.com/codex/tasks/task_e_686f77f8f2b08328be76dbc970c07529