### PR TITLE
Add performance and error tracking

### DIFF
--- a/fahndung-001/prisma/migrations/20250727000000_add-performance-logs/migration.sql
+++ b/fahndung-001/prisma/migrations/20250727000000_add-performance-logs/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "PerformanceMetric" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "duration" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "PerformanceMetric_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ErrorLog" (
+    "id" SERIAL NOT NULL,
+    "message" TEXT NOT NULL,
+    "stack" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ErrorLog_pkey" PRIMARY KEY ("id")
+);

--- a/fahndung-001/prisma/schema.prisma
+++ b/fahndung-001/prisma/schema.prisma
@@ -73,3 +73,17 @@ model VerificationToken {
 
   @@unique([identifier, token])
 }
+
+model PerformanceMetric {
+  id        Int      @id @default(autoincrement())
+  name      String
+  duration  Int
+  createdAt DateTime @default(now())
+}
+
+model ErrorLog {
+  id        Int      @id @default(autoincrement())
+  message   String
+  stack     String?
+  createdAt DateTime @default(now())
+}

--- a/fahndung-001/src/app/api/performance/stream/route.ts
+++ b/fahndung-001/src/app/api/performance/stream/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from "next/server";
+import { performanceEmitter } from "~/lib/performance";
+
+export const GET = async (_req: NextRequest) => {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const send = (metric: unknown) => {
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(metric)}\n\n`),
+        );
+      };
+
+      performanceEmitter.on("metric", send);
+
+      const interval = setInterval(() => {
+        controller.enqueue(encoder.encode(": heartbeat\n\n"));
+      }, 10000);
+
+      controller.oncancel = () => {
+        clearInterval(interval);
+        performanceEmitter.off("metric", send);
+      };
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+};

--- a/fahndung-001/src/app/dashboard/PerformanceMetrics.tsx
+++ b/fahndung-001/src/app/dashboard/PerformanceMetrics.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Metric {
+  id: number;
+  name: string;
+  duration: number;
+  createdAt: string;
+}
+
+export default function PerformanceMetrics() {
+  const [metrics, setMetrics] = useState<Metric[]>([]);
+
+  useEffect(() => {
+    const es = new EventSource("/api/performance/stream");
+
+    es.onmessage = (ev) => {
+      const metric = JSON.parse(ev.data) as Metric;
+      setMetrics((prev) => [metric, ...prev].slice(0, 20));
+    };
+
+    return () => {
+      es.close();
+    };
+  }, []);
+
+  return (
+    <div className="mt-8">
+      <h2 className="text-lg font-semibold text-gray-900">
+        Performance Metrics
+      </h2>
+      <ul className="mt-4 space-y-2">
+        {metrics.map((m) => (
+          <li key={m.id} className="text-sm text-gray-700">
+            {m.name}: {m.duration}ms
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/fahndung-001/src/app/dashboard/page.tsx
+++ b/fahndung-001/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from 'next/link';
+import PerformanceMetrics from "./PerformanceMetrics";
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -203,8 +204,9 @@ export default function DashboardPage() {
                 </div>
               </div>
             </div>
-          </div>
         </div>
+      </div>
+      <PerformanceMetrics />
       </div>
     </div>
   );

--- a/fahndung-001/src/lib/error-tracking.ts
+++ b/fahndung-001/src/lib/error-tracking.ts
@@ -1,0 +1,16 @@
+import { db } from "~/server/db";
+
+export function initErrorTracking() {
+  process.on("unhandledRejection", async (reason) => {
+    const error = reason instanceof Error ? reason : new Error(String(reason));
+    await db.errorLog.create({
+      data: { message: error.message, stack: error.stack },
+    });
+  });
+
+  process.on("uncaughtException", async (error) => {
+    await db.errorLog.create({
+      data: { message: error.message, stack: error.stack },
+    });
+  });
+}

--- a/fahndung-001/src/lib/performance.ts
+++ b/fahndung-001/src/lib/performance.ts
@@ -1,0 +1,26 @@
+import { EventEmitter } from "events";
+import { db } from "~/server/db";
+
+export const performanceEmitter = new EventEmitter();
+
+export function TrackTiming(name: string) {
+  return function (
+    _target: unknown,
+    _propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    const original = descriptor.value as (...args: unknown[]) => unknown;
+    descriptor.value = async function (...args: unknown[]) {
+      const start = Date.now();
+      try {
+        return await original.apply(this, args);
+      } finally {
+        const duration = Date.now() - start;
+        const metric = await db.performanceMetric.create({
+          data: { name, duration },
+        });
+        performanceEmitter.emit("metric", metric);
+      }
+    };
+  };
+}

--- a/fahndung-001/src/server/db.ts
+++ b/fahndung-001/src/server/db.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 
 import { env } from "~/env";
+import { initErrorTracking } from "~/lib/error-tracking";
 
 const createPrismaClient = () =>
   new PrismaClient({
@@ -15,3 +16,5 @@ const globalForPrisma = globalThis as unknown as {
 export const db = globalForPrisma.prisma ?? createPrismaClient();
 
 if (env.NODE_ENV !== "production") globalForPrisma.prisma = db;
+
+initErrorTracking();


### PR DESCRIPTION
## Summary
- extend Prisma schema with `PerformanceMetric` and `ErrorLog`
- track function timing via `TrackTiming` decorator
- track unhandled errors with `initErrorTracking`
- expose SSE endpoint at `/api/performance/stream`
- stream metrics in dashboard via new component
- update migrations

## Testing
- `pnpm lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_686f77f9c0d48328bf58f5e851c58811