### PR TITLE
Fix admin permission import

### DIFF
--- a/fahndung-001/src/server/permissions.ts
+++ b/fahndung-001/src/server/permissions.ts
@@ -1,1 +1,6 @@
-}
+export {
+  requireAuth,
+  requireRole,
+  checkPermission,
+  requirePermission,
+} from './auth/rbac';


### PR DESCRIPTION
## Summary
- proxy to RBAC helpers in `src/server/permissions.ts`

## Testing
- `pnpm --filter fahndung-t3a lint` *(fails: Invalid environment variables and lint errors)*
- `pnpm --filter fahndung-t3a build` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_686f86c8a8a48328952cbb6e63c14bac