### PR TITLE
feat(auth): include user role in session

### DIFF
--- a/fahndung-001/src/server/auth/config.ts
+++ b/fahndung-001/src/server/auth/config.ts
@@ -1,5 +1,6 @@
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { type DefaultSession, type NextAuthConfig } from "next-auth";
+import type { Role } from "@prisma/client";
 import DiscordProvider from "next-auth/providers/discord";
 import CredentialsProvider from "next-auth/providers/credentials";
 import bcrypt from "bcryptjs";
@@ -17,14 +18,14 @@ declare module "next-auth" {
     user: {
       id: string;
       // ...other properties
-      // role: UserRole;
+      role: Role;
     } & DefaultSession["user"];
   }
 
-  // interface User {
-  //   // ...other properties
-  //   // role: UserRole;
-  // }
+  interface User {
+    // ...other properties
+    role: Role;
+  }
 }
 
 /**
@@ -72,6 +73,7 @@ export const authConfig = {
       user: {
         ...session.user,
         id: user.id,
+        role: user.role,
       },
     }),
   },


### PR DESCRIPTION
## Summary
- extend NextAuth session and user types with Role
- expose `role` via session callback

## Testing
- `pnpm --filter fahndung-t3a lint` *(fails: `next` not found)*
- `pnpm --filter fahndung-t3a typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f86ca963083288c1e70bf8c711ae7