### PR TITLE
Fix route params in detail page

### DIFF
--- a/fahndung-001/src/app/fahndung/[id]/page.tsx
+++ b/fahndung-001/src/app/fahndung/[id]/page.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link';
 
 interface FahndungDetailProps {
-  params: Promise<{ id: string }>
+  params: { id: string }
 }
 
 export default async function FahndungDetail({ params }: FahndungDetailProps) {
-  const { id } = await params;
+  const { id } = params;
   return (
     <div className="max-w-2xl mx-auto py-12">
       <h1 className="text-3xl font-bold mb-6">Fahndung #{id}</h1>


### PR DESCRIPTION
## Summary
- simplify param interface in `page.tsx`
- remove unnecessary `await` when reading route params

## Testing
- `pnpm lint` *(fails: Local package.json exists, but node_modules missing)*
- `pnpm install` *(fails: Prisma schema validation error)*

------
https://chatgpt.com/codex/tasks/task_e_686f86cebd508328981b9e4f271246d3