### PR TITLE
Add Fahndung model and router

### DIFF
--- a/fahndung-001/prisma/migrations/20250801000000_add-fahndung/migration.sql
+++ b/fahndung-001/prisma/migrations/20250801000000_add-fahndung/migration.sql
@@ -1,0 +1,23 @@
+-- CreateEnum
+CREATE TYPE "FahndungType" AS ENUM ('PERSON', 'VEHICLE', 'OBJECT');
+
+-- CreateTable
+CREATE TABLE "Fahndung" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "status" "Status" NOT NULL DEFAULT 'NEW',
+    "type" "FahndungType" NOT NULL,
+    "reward" DOUBLE PRECISION,
+    "gender" TEXT NOT NULL,
+    "age" INTEGER NOT NULL,
+    "lastSeen" TIMESTAMP(3) NOT NULL,
+    "location" TEXT NOT NULL,
+    "imageURL" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "Fahndung_pkey" PRIMARY KEY ("id")
+);
+

--- a/fahndung-001/prisma/schema.prisma
+++ b/fahndung-001/prisma/schema.prisma
@@ -93,4 +93,42 @@ model VerificationToken {
   @@unique([identifier, token])
 }
 
+model AuditLog {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  userId    String?
+  ip        String?
+  userAgent String?
+
+  action   String
+  entity   String
+  entityId String
+  success  Boolean
+  details  Json
+
+  @@index([entity, entityId])
 }
+
+enum FahndungType {
+  PERSON
+  VEHICLE
+  OBJECT
+}
+
+model Fahndung {
+  id          Int          @id @default(autoincrement())
+  title       String
+  description String
+  status      Status       @default(NEW)
+  type        FahndungType
+  reward      Float?
+  gender      String
+  age         Int
+  lastSeen    DateTime
+  location    String
+  imageURL    String
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+  deletedAt   DateTime?
+}
+

--- a/fahndung-001/src/server/api/root.ts
+++ b/fahndung-001/src/server/api/root.ts
@@ -1,4 +1,5 @@
 import { postRouter } from "~/server/api/routers/post";
+import { fahndungRouter } from "~/server/api/routers/fahndung";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
 /**
@@ -8,6 +9,7 @@ import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
  */
 export const appRouter = createTRPCRouter({
   post: postRouter,
+  fahndung: fahndungRouter,
 });
 
 // export type definition of API

--- a/fahndung-001/src/server/api/routers/fahndung.ts
+++ b/fahndung-001/src/server/api/routers/fahndung.ts
@@ -1,0 +1,67 @@
+import { Status, FahndungType } from "@prisma/client";
+import { z } from "zod";
+
+import {
+  createTRPCRouter,
+  protectedProcedure,
+} from "~/server/api/trpc";
+import { requirePermission } from "~/server/auth/rbac";
+import { createAuditLog } from "~/lib/audit";
+
+export const fahndungSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().min(1),
+  status: z.nativeEnum(Status).optional(),
+  type: z.nativeEnum(FahndungType),
+  reward: z.number().optional(),
+  gender: z.string(),
+  age: z.number(),
+  lastSeen: z.date(),
+  location: z.string(),
+  imageURL: z.string().url(),
+});
+
+export const fahndungRouter = createTRPCRouter({
+  create: protectedProcedure
+    .input(fahndungSchema)
+    .mutation(async ({ ctx, input }) => {
+      await requirePermission("fahndung:create", ctx.session);
+      const fahndung = await ctx.db.fahndung.create({ data: input });
+      void createAuditLog({
+        action: "create",
+        entity: "Fahndung",
+        entityId: String(fahndung.id),
+        success: true,
+        userId: ctx.session.user.id,
+        headers: ctx.headers,
+      });
+      return fahndung;
+    }),
+
+  get: protectedProcedure
+    .input(z.object({ id: z.number() }))
+    .query(async ({ ctx, input }) => {
+      await requirePermission("fahndung:view", ctx.session);
+      return ctx.db.fahndung.findUnique({ where: { id: input.id } });
+    }),
+
+  list: protectedProcedure.query(async ({ ctx }) => {
+    await requirePermission("fahndung:list", ctx.session);
+    return ctx.db.fahndung.findMany();
+  }),
+
+  update: protectedProcedure
+    .input(fahndungSchema.merge(z.object({ id: z.number() })))
+    .mutation(async ({ ctx, input }) => {
+      await requirePermission("fahndung:edit", ctx.session);
+      const { id, ...data } = input;
+      return ctx.db.fahndung.update({ where: { id }, data });
+    }),
+
+  delete: protectedProcedure
+    .input(z.object({ id: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      await requirePermission("fahndung:delete", ctx.session);
+      return ctx.db.fahndung.delete({ where: { id: input.id } });
+    }),
+});


### PR DESCRIPTION
## Summary
- add `Fahndung` model in Prisma schema with enums and audit log preserved
- generate SQL migration for `Fahndung`
- expose RBAC-protected `fahndungRouter` with CRUD handlers
- register new router in `appRouter`

## Testing
- `pnpm lint` *(fails: Invalid environment variables and lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f86d249bc83288deeacb9deb789f5