### PR TITLE
Add password and role to User model

### DIFF
--- a/fahndung-001/prisma/schema.prisma
+++ b/fahndung-001/prisma/schema.prisma
@@ -72,6 +72,9 @@ model User {
   name          String?
   email         String?   @unique
 
+  password      String?
+  role          Role      @default(USER)
+
   emailVerified DateTime?
   image         String?
   accounts      Account[]


### PR DESCRIPTION
## Summary
- add `password` and `role` fields in Prisma `User` model
- regenerate Prisma client

## Testing
- `pnpm install`
- `pnpm exec prisma migrate dev --name add-user-fields` *(fails: Can't reach database server)*
- `pnpm exec prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_686f9ba7716483288f8ea79d0d703515