### PR TITLE
Fix bcrypt import for users actions

### DIFF
--- a/.changeset/patch-bcryptjs.md
+++ b/.changeset/patch-bcryptjs.md
@@ -1,0 +1,4 @@
+---
+"fahndung-t3a": patch
+---
+Switch user password hashing to use bcryptjs module.

--- a/fahndung-001/src/app/admin/users/actions.ts
+++ b/fahndung-001/src/app/admin/users/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { z } from "zod";
-import bcrypt from "bcrypt";
+import bcrypt from "bcryptjs";
 import { revalidatePath } from "next/cache";
 
 import { db } from "~/server/db";


### PR DESCRIPTION
## Summary
- use `bcryptjs` for user password hashing
- add patch changeset for package

## Testing
- `pnpm install`
- `SKIP_ENV_VALIDATION=1 pnpm check` *(fails: command exited with code 2)*
- `node -e "const bcrypt = require('./fahndung-001/node_modules/bcryptjs'); console.log(typeof bcrypt.hash);"`

------
https://chatgpt.com/codex/tasks/task_e_686f9bab4ef48328a66370f90ff8a23f